### PR TITLE
Improve voice stealing for notes by tracking oldest `time_of_note_on` rather than playhead position.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instrument"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A foundational type for performable musical instruments. Converts discrete note events to a continuous signal of amplitude and frequency over N number of voices. Useful for instruments such as synthesizers or samplers."
 readme = "README.md"

--- a/src/note_freq.rs
+++ b/src/note_freq.rs
@@ -124,7 +124,7 @@ impl NoteFreqGenerator for Portamento {
         // If some note is already playing, take it to use for portamento.
         let maybe_last_hz = match maybe_voice {
             Some(voice) => match voice.note.as_ref() {
-                Some(&(NoteState::Playing, _, ref porta_freq, _)) => Some(porta_freq.hz()),
+                Some(note) if note.state == NoteState::Playing => Some(note.freq.hz()),
                 _ => None,
             },
             None => None,
@@ -167,7 +167,7 @@ impl NoteFreqGenerator for DynamicGenerator {
                 // If some note is already playing, take it to use for portamento.
                 let maybe_last_hz = match maybe_voice {
                     Some(voice) => match voice.note.as_ref() {
-                        Some(&(NoteState::Playing, _, ref porta_freq, _)) => Some(porta_freq.hz()),
+                        Some(note) if note.state == NoteState::Playing => Some(note.freq.hz()),
                         _ => None,
                     },
                     None => None,


### PR DESCRIPTION
- Make the `does_hz_match` function public for downstream use.
- Introduce a `Note` type for the `Option<Note>` held by `Voice`s. Add a `time_of_note_on` field in order to correctly replace oldest note upon Poly `note_on` method.
- Remove serialization of individual `Voice`s in favour of serializing the number of `Voice`s instead.
